### PR TITLE
Feat/#3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,12 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
+        "@nestjs/jwt": "^11.0.0",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/typeorm": "^11.0.0",
+        "@types/bcrypt": "^6.0.0",
+        "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "nest-winston": "^1.10.2",
@@ -2564,6 +2567,19 @@
         }
       }
     },
+    "node_modules/@nestjs/jwt": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.0.tgz",
+      "integrity": "sha512-v7YRsW3Xi8HNTsO+jeHSEEqelX37TVWgwt+BcxtkG/OfXJEOs6GZdbdza200d6KqId1pJQZ6UPj1F0M6E+mxaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "9.0.7",
+        "jsonwebtoken": "9.0.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/mapped-types": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
@@ -3344,6 +3360,15 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -3495,6 +3520,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.7.tgz",
+      "integrity": "sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -3513,7 +3547,6 @@
       "version": "22.16.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.4.tgz",
       "integrity": "sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5088,6 +5121,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/bin-version": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz",
@@ -5269,6 +5316,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -6162,6 +6215,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -8750,6 +8812,49 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8874,6 +8979,42 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8886,6 +9027,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -9323,6 +9470,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -9331,6 +9487,17 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -10516,7 +10683,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12133,7 +12299,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "export NODE_ENV=local && nest start --watch",
+    "start:dev": "export NODE_ENV=local && nest start --watch && npm run swagger:generate",
     "start:debug": "export NODE_ENV=local && nest start --debug --watch",
     "start:prod": "export NODE_ENV=production && node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
@@ -17,15 +17,18 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "swagger:generate": "node scripts/generate-swagger-spec.js"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/jwt": "^11.0.0",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
+    "@types/bcrypt": "^6.0.0",
+    "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "nest-winston": "^1.10.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,8 @@ import { LoggingModule } from './core/interceptors/logging/logging.module';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './application/auth/auth.module';
+import { DBModule } from './application/DB/DB.module';
 
 @Module({
   imports: [
@@ -20,6 +22,8 @@ import { AppService } from './app.service';
       synchronize: true, // 개발환경에서만 true
     }),
     LoggingModule,
+    DBModule,
+    AuthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/application/DB/DB.module.ts
+++ b/src/application/DB/DB.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { WinstonLoggerService } from 'src/core/interceptors/logging/winston-logger.service';
+import { User } from './entity/user';
+import { UserQuery } from './query/user.query';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [WinstonLoggerService, UserQuery],
+  exports: [UserQuery],
+})
+export class DBModule {}

--- a/src/application/DB/entity/user.ts
+++ b/src/application/DB/entity/user.ts
@@ -24,7 +24,6 @@ export class User {
   @Column({
     name: 'u_refresh_token',
     type: 'varchar',
-    length: 255,
     nullable: true,
   })
   uRefreshToken: string;

--- a/src/application/DB/entity/user.ts
+++ b/src/application/DB/entity/user.ts
@@ -1,0 +1,37 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 't_user' })
+export class User {
+  @PrimaryColumn({
+    name: 'u_id',
+    type: 'varchar',
+    default: () => 'gen_random_uuid()',
+  })
+  uId: string;
+
+  @Column({ name: 'u_role', type: 'varchar', length: 10, default: 'admin' })
+  uRole: string;
+
+  @Column({ name: 'u_name', type: 'varchar', length: 15, nullable: true })
+  uName: string;
+
+  @Column({ name: 'u_email', type: 'varchar', length: 20, unique: true })
+  uEmail: string;
+
+  @Column({ name: 'u_password', type: 'varchar', length: 255 })
+  uPassword: string;
+
+  @Column({
+    name: 'u_refresh_token',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  uRefreshToken: string;
+
+  @Column({ name: 'u_created_at', type: 'bigint' })
+  uCreatedAt: number;
+
+  @Column({ name: 'u_mod_at', type: 'bigint', nullable: true })
+  uModAt: number;
+}

--- a/src/application/DB/query/user.query.ts
+++ b/src/application/DB/query/user.query.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../entity/user';
+import { WinstonLoggerService } from 'src/core/interceptors/logging/winston-logger.service';
+import { getSeoulTimestamp } from 'src/core/utils/time';
+
+@Injectable()
+export class UserQuery {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  async createUser(email: string, password: string) {
+    try {
+      const user = this.userRepository.create({
+        uEmail: email,
+        uPassword: password,
+        uCreatedAt: getSeoulTimestamp(),
+      });
+
+      await this.userRepository.save(user);
+
+      this.logger.debug(`UserQuery.createUser success: ${email}`);
+      return user;
+    } catch (error) {
+      this.logger.error('UserQuery.createUser Failed.');
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async findUserByEmail(email: string) {
+    return this.userRepository.findOne({ where: { uEmail: email } });
+  }
+
+  async updateUserRefreshToken(uId: string, refreshToken: string) {
+    return this.userRepository.update(uId, { uRefreshToken: refreshToken });
+  }
+}

--- a/src/application/DB/query/user.query.ts
+++ b/src/application/DB/query/user.query.ts
@@ -32,6 +32,10 @@ export class UserQuery {
     }
   }
 
+  async findUserById(uId: string) {
+    return this.userRepository.findOne({ where: { uId: uId } });
+  }
+
   async findUserByEmail(email: string) {
     return this.userRepository.findOne({ where: { uEmail: email } });
   }

--- a/src/application/auth/auth.module.ts
+++ b/src/application/auth/auth.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { DBModule } from '../DB/DB.module';
+import { ConfigModule } from '@nestjs/config';
+import { WinstonLoggerService } from '../../core/interceptors/logging/winston-logger.service';
+import { JwtUtil } from '../../core/utils/jwt';
+import jwtConfig from '../../config/jwt.config';
+import { AuthController } from './controller/auth.controller';
+import { AuthService } from './service/auth.service';
+import { JwtService } from '@nestjs/jwt';
+
+@Module({
+  imports: [DBModule, ConfigModule.forFeature(jwtConfig)],
+  controllers: [AuthController],
+  providers: [WinstonLoggerService, AuthService, JwtService, JwtUtil],
+})
+export class AuthModule {}

--- a/src/application/auth/controller/auth.controller.ts
+++ b/src/application/auth/controller/auth.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Post, UsePipes } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CustomValidationPipe } from 'src/core/pipes/validation';
+import { JsonResponse } from 'src/core/utils/json-response';
+
+import { AuthService } from '../service/auth.service';
+import { LoginDto, SignUpDto } from '../dto/auth.dto';
+import {
+  SignUpSwagger,
+  LoginSwagger,
+} from 'src/core/swagger/decorator/auth/auth.service';
+
+@ApiTags('Auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('signup')
+  @UsePipes(CustomValidationPipe)
+  @ApiOperation({ summary: '회원가입' })
+  @SignUpSwagger()
+  async signUp(@Body() dto: SignUpDto) {
+    const result = await this.authService.signUp(dto.email, dto.password);
+
+    const response = new JsonResponse();
+    response.set('data', result);
+
+    return response.of();
+  }
+
+  @Post('login')
+  @UsePipes(CustomValidationPipe)
+  @ApiOperation({ summary: '로그인' })
+  @LoginSwagger()
+  async login(@Body() dto: LoginDto) {
+    const result = await this.authService.login(dto.email, dto.password);
+
+    const response = new JsonResponse();
+    response.set('data', result);
+
+    return response.of();
+  }
+}

--- a/src/application/auth/controller/auth.controller.ts
+++ b/src/application/auth/controller/auth.controller.ts
@@ -6,7 +6,7 @@ import {
   UseGuards,
   UsePipes,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiHeader, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CustomValidationPipe } from 'src/core/pipes/validation';
 import { JsonResponse } from 'src/core/utils/json-response';
 import { AuthService } from '../service/auth.service';
@@ -54,6 +54,14 @@ export class AuthController {
   @Get('logout')
   @UseGuards(AuthGuard)
   @ApiOperation({ summary: '로그아웃' })
+  @ApiHeader({
+    name: 'authorization',
+    description: 'Bearer 액세스 토큰',
+  })
+  @ApiHeader({
+		name: 'cookie',
+		description: '리프레시 토큰이 포함된 쿠키',
+  })
   @LogoutSwagger()
   async logout(@User() user: UserInfo) {
     await this.authService.logout(user.uId);
@@ -65,6 +73,14 @@ export class AuthController {
   @Get('user')
   @UseGuards(AuthGuard)
   @ApiOperation({ summary: '유저 정보 조회' })
+  @ApiHeader({
+    name: 'authorization',
+    description: 'Bearer 액세스 토큰',
+  })
+  @ApiHeader({
+		name: 'cookie',
+		description: '리프레시 토큰이 포함된 쿠키',
+  })
   @GetUserInfoSwagger()
   async getUserInfo(@User() user: UserInfo) {
     const response = new JsonResponse();

--- a/src/application/auth/controller/auth.controller.ts
+++ b/src/application/auth/controller/auth.controller.ts
@@ -1,14 +1,24 @@
-import { Body, Controller, Post, UsePipes } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  UseGuards,
+  UsePipes,
+} from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CustomValidationPipe } from 'src/core/pipes/validation';
 import { JsonResponse } from 'src/core/utils/json-response';
-
 import { AuthService } from '../service/auth.service';
-import { LoginDto, SignUpDto } from '../dto/auth.dto';
+import { LoginRequestDto, SignUpRequestDto } from '../dto/auth.dto';
 import {
   SignUpSwagger,
   LoginSwagger,
+  LogoutSwagger,
+  GetUserInfoSwagger,
 } from 'src/core/swagger/decorator/auth/auth.service';
+import { AuthGuard } from 'src/core/guard/auth.guard';
+import { User, UserInfo } from 'src/core/guard/decorator/user.decorator';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -19,7 +29,7 @@ export class AuthController {
   @UsePipes(CustomValidationPipe)
   @ApiOperation({ summary: '회원가입' })
   @SignUpSwagger()
-  async signUp(@Body() dto: SignUpDto) {
+  async signUp(@Body() dto: SignUpRequestDto) {
     const result = await this.authService.signUp(dto.email, dto.password);
 
     const response = new JsonResponse();
@@ -32,11 +42,33 @@ export class AuthController {
   @UsePipes(CustomValidationPipe)
   @ApiOperation({ summary: '로그인' })
   @LoginSwagger()
-  async login(@Body() dto: LoginDto) {
+  async login(@Body() dto: LoginRequestDto) {
     const result = await this.authService.login(dto.email, dto.password);
 
     const response = new JsonResponse();
     response.set('data', result);
+
+    return response.of();
+  }
+
+  @Get('logout')
+  @UseGuards(AuthGuard)
+  @ApiOperation({ summary: '로그아웃' })
+  @LogoutSwagger()
+  async logout(@User() user: UserInfo) {
+    await this.authService.logout(user.uId);
+
+    const response = new JsonResponse();
+    return response.of();
+  }
+
+  @Get('user')
+  @UseGuards(AuthGuard)
+  @ApiOperation({ summary: '유저 정보 조회' })
+  @GetUserInfoSwagger()
+  async getUserInfo(@User() user: UserInfo) {
+    const response = new JsonResponse();
+    response.set('data', user);
 
     return response.of();
   }

--- a/src/application/auth/dto/auth.dto.ts
+++ b/src/application/auth/dto/auth.dto.ts
@@ -1,7 +1,7 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class SignUpDto {
+export class SignUpRequestDto {
   @ApiProperty({
     description: '이메일',
     example: 'test@test.com',
@@ -22,7 +22,7 @@ export class SignUpDto {
   password: string;
 }
 
-export class LoginDto {
+export class LoginRequestDto {
   @ApiProperty({
     description: '이메일',
     example: 'test@test.com',

--- a/src/application/auth/dto/auth.dto.ts
+++ b/src/application/auth/dto/auth.dto.ts
@@ -1,0 +1,44 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SignUpDto {
+  @ApiProperty({
+    description: '이메일',
+    example: 'test@test.com',
+  })
+  @IsNotEmpty({ message: '이메일은 필수 입력 항목입니다.' })
+  @IsEmail(
+    { allow_display_name: false },
+    { message: '이메일 형식이 올바르지 않습니다.' },
+  )
+  email: string;
+
+  @ApiProperty({
+    description: '비밀번호',
+    example: '123456',
+  })
+  @IsNotEmpty({ message: '비밀번호는 필수 입력 항목입니다.' })
+  @IsString({ message: '비밀번호는 문자열이어야 합니다.' })
+  password: string;
+}
+
+export class LoginDto {
+  @ApiProperty({
+    description: '이메일',
+    example: 'test@test.com',
+  })
+  @IsNotEmpty({ message: '이메일은 필수 입력 항목입니다.' })
+  @IsEmail(
+    { allow_display_name: false },
+    { message: '이메일 형식이 올바르지 않습니다.' },
+  )
+  email: string;
+
+  @ApiProperty({
+    description: '비밀번호',
+    example: '123456',
+  })
+  @IsNotEmpty({ message: '비밀번호는 필수 입력 항목입니다.' })
+  @IsString({ message: '비밀번호는 문자열이어야 합니다.' })
+  password: string;
+}

--- a/src/application/auth/service/auth.service.ts
+++ b/src/application/auth/service/auth.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { WinstonLoggerService } from 'src/core/interceptors/logging/winston-logger.service';
+import { UserQuery } from 'src/application/DB/query/user.query';
+import { ErrorCode } from 'src/core/exception/const/error-code';
+import { GlobalException } from 'src/core/exception/global.exception';
+import { JwtUtil } from 'src/core/utils/jwt';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly logger: WinstonLoggerService,
+    private readonly jwtUtil: JwtUtil,
+    private readonly userQuery: UserQuery,
+  ) {}
+
+  async signUp(email: string, password: string) {
+    try {
+      const user = await this.userQuery.findUserByEmail(email);
+      if (user) {
+        this.logger.error(`User already exists: ${email}`);
+        throw new GlobalException(
+          'User already exists',
+          409,
+          ErrorCode.DUPLICATION,
+        );
+      }
+
+      // 비밀번호 해싱
+      const hashedPassword = await bcrypt.hash(password, 10);
+      const newUser = await this.userQuery.createUser(email, hashedPassword);
+
+      // JWT 토큰 생성
+      const token = await this.jwtUtil.generateToken({
+        uId: newUser.uId,
+        uEmail: newUser.uEmail,
+        uRole: newUser.uRole,
+      });
+
+      await this.userQuery.updateUserRefreshToken(
+        newUser.uId,
+        token.refreshToken,
+      );
+
+      this.logger.debug(`AuthService.signUp success: ${email}`);
+      return token;
+    } catch (error) {
+      this.logger.error('AuthService.signUp Failed.');
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async login(email: string, password: string) {
+    try {
+      const user = await this.userQuery.findUserByEmail(email);
+      if (!user) {
+        this.logger.error(`User not found: ${email}`);
+        throw new GlobalException(
+          'User not found',
+          404,
+          ErrorCode.USER_NOT_FOUND,
+        );
+      }
+
+      // 비밀번호 검증
+      const isPasswordValid = await bcrypt.compare(password, user.uPassword);
+      if (!isPasswordValid) {
+        this.logger.error(`Invalid password: ${email}`);
+        throw new GlobalException(
+          'Invalid password',
+          401,
+          ErrorCode.USER_NOT_AUTHENTICATION,
+        );
+      }
+
+      // JWT 토큰 생성
+      const token = await this.jwtUtil.generateToken({
+        uId: user.uId,
+        uEmail: user.uEmail,
+        uRole: user.uRole,
+      });
+
+      await this.userQuery.updateUserRefreshToken(user.uId, token.refreshToken);
+
+      this.logger.debug(`AuthService.login success: ${email}`);
+      return token;
+    } catch (error) {
+      this.logger.error('AuthService.login Failed.');
+      this.logger.error(error);
+      throw error;
+    }
+  }
+}

--- a/src/application/auth/service/auth.service.ts
+++ b/src/application/auth/service/auth.service.ts
@@ -33,6 +33,7 @@ export class AuthService {
       // JWT 토큰 생성
       const token = await this.jwtUtil.generateToken({
         uId: newUser.uId,
+        uName: newUser.uName,
         uEmail: newUser.uEmail,
         uRole: newUser.uRole,
       });
@@ -77,6 +78,7 @@ export class AuthService {
       // JWT 토큰 생성
       const token = await this.jwtUtil.generateToken({
         uId: user.uId,
+        uName: user.uName,
         uEmail: user.uEmail,
         uRole: user.uRole,
       });
@@ -87,6 +89,16 @@ export class AuthService {
       return token;
     } catch (error) {
       this.logger.error('AuthService.login Failed.');
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async logout(userId: string) {
+    try {
+      await this.userQuery.updateUserRefreshToken(userId, '');
+    } catch (error) {
+      this.logger.error('AuthService.logout Failed.');
       this.logger.error(error);
       throw error;
     }

--- a/src/config/jwt.config.ts
+++ b/src/config/jwt.config.ts
@@ -1,0 +1,6 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('jwt', () => ({
+  jwtSecretKey: process.env.JWT_SECRET_KEY,
+  jwtRefreshSecretKey: process.env.JWT_REFRESH_SECRET_KEY,
+}));

--- a/src/core/exception/const/error-code.ts
+++ b/src/core/exception/const/error-code.ts
@@ -15,6 +15,8 @@ export const ErrorCode = {
   DUPLICATION: -5,
   /** 수정 불가 오류 */
   NOT_UPDATE: -6,
+  /** 사용자 없음 */
+  USER_NOT_FOUND: -7,
 
   /** JWT 인증 관련 오류 코드 */
   /** 인증 실패 */

--- a/src/core/filter/validation.filter.ts
+++ b/src/core/filter/validation.filter.ts
@@ -41,7 +41,16 @@ export class ValidationExceptionFilter implements ExceptionFilter {
     }
 
     // 형식 오류 (matches, length, isString 등)
-    const formatKeys = ['matches', 'length', 'isString', 'isNumber', 'isIn'];
+    const formatKeys = [
+      'matches',
+      'length',
+      'isString',
+      'isBoolean',
+      'isNumber',
+      'isIn',
+      'isObject',
+      'isEmail',
+    ];
     if (constraintKeys.some((key) => formatKeys.includes(key))) {
       return ErrorCode.NOT_VALIDITY;
     }

--- a/src/core/guard/auth.guard.ts
+++ b/src/core/guard/auth.guard.ts
@@ -1,0 +1,68 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtUtil } from '../utils/jwt';
+import { WinstonLoggerService } from '../interceptors/logging/winston-logger.service';
+import { GlobalException } from '../exception/global.exception';
+import { ErrorCode } from '../exception/const/error-code';
+import { UserInfo } from './decorator/user.decorator';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    private jwtUtil: JwtUtil,
+    private logger: WinstonLoggerService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    this.logger.debug('AuthGuard: Authentication required');
+
+    const request = context.switchToHttp().getRequest();
+    const { accessToken, refreshToken } = await this.jwtUtil.extractTokens(request);
+
+    if (!accessToken || !refreshToken) {
+      throw new GlobalException(
+        '헤더 또는 쿠키가 필요합니다.',
+        401,
+        ErrorCode.USER_NOT_AUTHENTICATION,
+      );
+    }
+
+    try {
+      const result = await this.jwtUtil.verifyToken(accessToken, refreshToken);
+
+      if (!result.status) {
+        throw new GlobalException(
+          '토큰 검증에 실패했습니다.',
+          401,
+          ErrorCode.INVALID_TOKEN,
+        );
+      }
+
+      // 새로운 액세스 토큰이 발급된 경우 응답 헤더에 추가
+      if (result.newAccess) {
+        const response = context.switchToHttp().getResponse();
+        response.setHeader('Authorization', result.newAccess);
+      }
+
+      // 요청 객체에 사용자 정보 추가
+      if (result.payload) {
+        request.user = {
+          uId: result.payload.uId,
+          uName: result.payload.uName,
+          uEmail: result.payload.uEmail,
+          uRole: result.payload.uRole,
+        } as UserInfo;
+        this.logger.debug(`User authenticated: ${result.payload.uId}`);
+      }
+
+      return true;
+    } catch (error) {
+      this.logger.warn('AuthGuard: Authentication failed', error);
+      throw new GlobalException(
+        '인증에 실패했습니다.',
+        401,
+        ErrorCode.UNAUTHORIZED,
+      );
+    }
+  }
+}

--- a/src/core/guard/decorator/user.decorator.ts
+++ b/src/core/guard/decorator/user.decorator.ts
@@ -1,0 +1,13 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export interface UserInfo {
+  uId: string;
+  uName: string;
+  uEmail: string;
+  uRole: string;
+}
+
+export const User = createParamDecorator((data: unknown, ctx: ExecutionContext): UserInfo => {
+	const request = ctx.switchToHttp().getRequest();
+	return request.user as UserInfo;
+});

--- a/src/core/pipes/validation.ts
+++ b/src/core/pipes/validation.ts
@@ -78,6 +78,8 @@ export class CustomValidationPipe implements PipeTransform {
           'isBoolean',
           'isArray',
           'isObject',
+          'isEmail',
+          'isIn',
           'min',
           'max',
         ].includes(key),

--- a/src/core/swagger/decorator/auth/auth.service.ts
+++ b/src/core/swagger/decorator/auth/auth.service.ts
@@ -10,21 +10,49 @@ import {
 } from '../common.swagger';
 
 export class TokenDto {
+  @ApiProperty({
+    description: '액세스 토큰',
+    type: String,
+  })
   accessToken: string;
+
+  @ApiProperty({
+    description: '리프레시 토큰',
+    type: String,
+  })
   refreshToken: string;
 }
 
 export class UserInfoDto {
+  @ApiProperty({
+    description: '유저 ID',
+    type: String,
+  })
   uId: string;
+
+  @ApiProperty({
+    description: '유저 이름',
+    type: String,
+  })
   uName: string;
+
+  @ApiProperty({
+    description: '유저 이메일',
+    type: String,
+  })
   uEmail: string;
+
+  @ApiProperty({
+    description: '유저 역할',
+    type: String,
+  })
   uRole: string;
 }
 
 export class SignUpResponseDto extends ApiResponseDto<TokenDto> {
   @ApiProperty({
     description: '토큰 정보',
-    type: Object,
+    type: TokenDto,
   })
   declare data: TokenDto;
 }
@@ -32,7 +60,7 @@ export class SignUpResponseDto extends ApiResponseDto<TokenDto> {
 export class LoginResponseDto extends ApiResponseDto<TokenDto> {
   @ApiProperty({
     description: '토큰 정보',
-    type: Object,
+    type: TokenDto,
   })
   declare data: TokenDto;
 }
@@ -42,7 +70,7 @@ export class LogoutResponseDto extends ApiResponseDto<void> {}
 export class GetUserInfoResponseDto extends ApiResponseDto<UserInfoDto> {
   @ApiProperty({
     description: '유저 정보',
-    type: Object,
+    type: UserInfoDto,
   })
   declare data: UserInfoDto;
 }

--- a/src/core/swagger/decorator/auth/auth.service.ts
+++ b/src/core/swagger/decorator/auth/auth.service.ts
@@ -10,25 +10,41 @@ import {
 } from '../common.swagger';
 
 export class TokenDto {
-  @ApiProperty({
-    description: '액세스 토큰',
-    example: 'accessToken',
-  })
   accessToken: string;
-
-  @ApiProperty({
-    description: '리프레시 토큰',
-    example: 'refreshToken',
-  })
   refreshToken: string;
 }
 
-export class TokenResponse extends ApiResponseDto<TokenDto> {
+export class UserInfoDto {
+  uId: string;
+  uName: string;
+  uEmail: string;
+  uRole: string;
+}
+
+export class SignUpResponseDto extends ApiResponseDto<TokenDto> {
   @ApiProperty({
     description: '토큰 정보',
-    type: TokenDto,
+    type: Object,
   })
   declare data: TokenDto;
+}
+
+export class LoginResponseDto extends ApiResponseDto<TokenDto> {
+  @ApiProperty({
+    description: '토큰 정보',
+    type: Object,
+  })
+  declare data: TokenDto;
+}
+
+export class LogoutResponseDto extends ApiResponseDto<void> {}
+
+export class GetUserInfoResponseDto extends ApiResponseDto<UserInfoDto> {
+  @ApiProperty({
+    description: '유저 정보',
+    type: Object,
+  })
+  declare data: UserInfoDto;
 }
 
 export function SignUpSwagger() {
@@ -37,7 +53,7 @@ export function SignUpSwagger() {
     ApiResponse({
       status: 200,
       description: '회원가입 성공',
-      type: TokenResponse,
+      type: SignUpResponseDto,
       examples: {
         success: {
           summary: '성공',
@@ -61,7 +77,7 @@ export function LoginSwagger() {
     ApiResponse({
       status: 200,
       description: '로그인 성공',
-      type: TokenResponse,
+      type: LoginResponseDto,
       examples: {
         success: {
           summary: '성공',
@@ -75,6 +91,57 @@ export function LoginSwagger() {
     }),
     ApiResponse(createValidationErrorResponse()),
     ApiResponse(createUserNotFoundErrorResponse()),
+    ApiResponse(createUnauthorizedErrorResponse()),
+    ApiResponse(createServerErrorResponse()),
+  );
+}
+
+export function LogoutSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: '로그아웃' }),
+    ApiResponse({ status: 200, description: '로그아웃 성공' }),
+    ApiResponse({
+      status: 200,
+      description: '로그아웃 성공',
+      type: LogoutResponseDto,
+      examples: {
+        success: {
+          summary: '성공',
+          value: {
+            code: 0,
+            message: 'SUCCESS',
+          },
+        },
+      },
+    }),
+    ApiResponse(createUnauthorizedErrorResponse()),
+    ApiResponse(createServerErrorResponse()),
+  );
+}
+
+export function GetUserInfoSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: '유저 정보 조회' }),
+    ApiResponse({
+      status: 200,
+      description: '유저 정보 조회 성공',
+      type: GetUserInfoResponseDto,
+      examples: {
+        success: {
+          summary: '성공',
+          value: {
+            code: 0,
+            message: 'SUCCESS',
+            data: {
+              uId: '1234567890',
+              uName: 'John Doe',
+              uEmail: 'john.doe@example.com',
+              uRole: 'user',
+            },
+          },
+        },
+      },
+    }),
     ApiResponse(createUnauthorizedErrorResponse()),
     ApiResponse(createServerErrorResponse()),
   );

--- a/src/core/swagger/decorator/auth/auth.service.ts
+++ b/src/core/swagger/decorator/auth/auth.service.ts
@@ -1,0 +1,81 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiProperty, ApiResponse } from '@nestjs/swagger';
+import {
+  createValidationErrorResponse,
+  createServerErrorResponse,
+  createUserNotFoundErrorResponse,
+  createDuplicationErrorResponse,
+  createUnauthorizedErrorResponse,
+  ApiResponseDto,
+} from '../common.swagger';
+
+export class TokenDto {
+  @ApiProperty({
+    description: '액세스 토큰',
+    example: 'accessToken',
+  })
+  accessToken: string;
+
+  @ApiProperty({
+    description: '리프레시 토큰',
+    example: 'refreshToken',
+  })
+  refreshToken: string;
+}
+
+export class TokenResponse extends ApiResponseDto<TokenDto> {
+  @ApiProperty({
+    description: '토큰 정보',
+    type: TokenDto,
+  })
+  declare data: TokenDto;
+}
+
+export function SignUpSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: '회원가입' }),
+    ApiResponse({
+      status: 200,
+      description: '회원가입 성공',
+      type: TokenResponse,
+      examples: {
+        success: {
+          summary: '성공',
+          value: {
+            code: 0,
+            message: 'SUCCESS',
+            data: { accessToken: 'accessToken', refreshToken: 'refreshToken' },
+          },
+        },
+      },
+    }),
+    ApiResponse(createValidationErrorResponse()),
+    ApiResponse(createDuplicationErrorResponse()),
+    ApiResponse(createServerErrorResponse()),
+  );
+}
+
+export function LoginSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: '로그인' }),
+    ApiResponse({
+      status: 200,
+      description: '로그인 성공',
+      type: TokenResponse,
+      examples: {
+        success: {
+          summary: '성공',
+          value: {
+            code: 0,
+            message: 'SUCCESS',
+            data: { accessToken: 'accessToken', refreshToken: 'refreshToken' },
+          },
+        },
+      },
+    }),
+    ApiResponse(createValidationErrorResponse()),
+    ApiResponse(createUserNotFoundErrorResponse()),
+    ApiResponse(createUnauthorizedErrorResponse()),
+    ApiResponse(createServerErrorResponse()),
+  );
+}

--- a/src/core/swagger/decorator/common.swagger.ts
+++ b/src/core/swagger/decorator/common.swagger.ts
@@ -1,0 +1,166 @@
+import { ApiProperty, ApiResponseOptions } from '@nestjs/swagger';
+
+export class ApiResponseDto<T> {
+  @ApiProperty({
+    description: '응답 코드',
+    example: 0,
+  })
+  code: number;
+
+  @ApiProperty({
+    description: '응답 메시지',
+    example: 'SUCCESS',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: '응답 데이터',
+    example: {},
+  })
+  data: T;
+}
+
+export function createValidationErrorResponse(): ApiResponseOptions {
+  return {
+    status: 400,
+    description: 'Validation 에러',
+    schema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'number',
+          description: 'Validation 에러 코드 (-1 ~ -6)',
+        },
+        message: {
+          type: 'string',
+          description: 'Validation 에러 메시지',
+        },
+      },
+    },
+    examples: {
+      validationError: {
+        summary: 'Validation 에러',
+        value: {
+          code: -2,
+          message: '유효하지 않은 형식입니다.',
+        },
+      },
+    },
+  };
+}
+
+export function createDuplicationErrorResponse(): ApiResponseOptions {
+  return {
+    status: 409,
+    description: '중복 오류',
+    schema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'number',
+          description: '중복 오류 코드 (-5)',
+        },
+        message: {
+          type: 'string',
+          description: '중복 오류 메시지',
+        },
+      },
+    },
+    examples: {
+      duplication: {
+        summary: '중복 오류',
+        value: {
+          code: -5,
+          message: '중복 오류',
+        },
+      },
+    },
+  };
+}
+
+export function createUnauthorizedErrorResponse(): ApiResponseOptions {
+  return {
+    status: 401,
+    description: '인증 에러',
+    schema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'number',
+          description: '인증 에러 코드 (-4, -10 ~ -12)',
+        },
+        message: {
+          type: 'string',
+          description: '인증 에러 메시지',
+        },
+      },
+    },
+    examples: {
+      unauthorized: {
+        summary: '인증 에러',
+        value: {
+          code: -10,
+          message: '인증에 실패했습니다.',
+        },
+      },
+    },
+  };
+}
+
+export function createUserNotFoundErrorResponse(): ApiResponseOptions {
+  return {
+    status: 404,
+    description: '사용자 없음',
+    schema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'number',
+          description: '사용자 없음 코드 (-7)',
+        },
+        message: {
+          type: 'string',
+          description: '사용자 없음 메시지',
+        },
+      },
+    },
+    examples: {
+      userNotFound: {
+        summary: '사용자 없음',
+        value: {
+          code: -7,
+          message: '사용자를 찾을 수 없습니다.',
+        },
+      },
+    },
+  };
+}
+
+export function createServerErrorResponse(): ApiResponseOptions {
+  return {
+    status: 500,
+    description: '서버 오류',
+    schema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'number',
+          description: '에러 코드',
+        },
+        message: {
+          type: 'string',
+          description: '에러 메시지',
+        },
+      },
+    },
+    examples: {
+      systemError: {
+        summary: '서버 오류',
+        value: {
+          code: -99,
+          message: 'SYSTEM_ERROR',
+        },
+      },
+    },
+  };
+}

--- a/src/core/swagger/decorator/common.swagger.ts
+++ b/src/core/swagger/decorator/common.swagger.ts
@@ -17,7 +17,7 @@ export class ApiResponseDto<T> {
     description: '응답 데이터',
     example: {},
   })
-  data: T;
+  data?: T;
 }
 
 export function createValidationErrorResponse(): ApiResponseOptions {

--- a/src/core/utils/jwt.ts
+++ b/src/core/utils/jwt.ts
@@ -1,0 +1,66 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import jwtConfig from '../../config/jwt.config';
+import { WinstonLoggerService } from '../interceptors/logging/winston-logger.service';
+import { GlobalException } from '../exception/global.exception';
+import { ErrorCode } from '../exception/const/error-code';
+
+interface JwtPayload {
+  uId: string;
+  uEmail: string;
+  uRole: string;
+}
+
+@Injectable()
+export class JwtUtil {
+  constructor(
+    private readonly logger: WinstonLoggerService,
+    private readonly jwtService: JwtService,
+    @Inject(jwtConfig.KEY)
+    private readonly config: ConfigType<typeof jwtConfig>,
+  ) {}
+
+  async generateToken(
+    payload: JwtPayload,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const accessToken = await this.generateAccessToken(payload);
+    const refreshToken = await this.generateRefreshToken(payload);
+
+    return { accessToken, refreshToken };
+  }
+
+  private async generateAccessToken(payload: JwtPayload): Promise<string> {
+    try {
+      return this.jwtService.sign(payload, {
+        secret: this.config.jwtSecretKey,
+        expiresIn: '1h',
+      });
+    } catch (error) {
+      this.logger.error('JwtUtil.generateAccessToken Failed.');
+      this.logger.error(error);
+      throw new GlobalException(
+        'Failed to generate access token',
+        500,
+        ErrorCode.ERROR,
+      );
+    }
+  }
+
+  private async generateRefreshToken(payload: JwtPayload): Promise<string> {
+    try {
+      return this.jwtService.sign(payload, {
+        secret: this.config.jwtRefreshSecretKey,
+        expiresIn: '7d',
+      });
+    } catch (error) {
+      this.logger.error('JwtUtil.generateRefreshToken Failed.');
+      this.logger.error(error);
+      throw new GlobalException(
+        'Failed to generate refresh token',
+        500,
+        ErrorCode.ERROR,
+      );
+    }
+  }
+}

--- a/src/core/utils/jwt.ts
+++ b/src/core/utils/jwt.ts
@@ -5,9 +5,11 @@ import jwtConfig from '../../config/jwt.config';
 import { WinstonLoggerService } from '../interceptors/logging/winston-logger.service';
 import { GlobalException } from '../exception/global.exception';
 import { ErrorCode } from '../exception/const/error-code';
+import { UserQuery } from '../../application/DB/query/user.query';
 
 interface JwtPayload {
   uId: string;
+  uName: string;
   uEmail: string;
   uRole: string;
 }
@@ -17,8 +19,8 @@ export class JwtUtil {
   constructor(
     private readonly logger: WinstonLoggerService,
     private readonly jwtService: JwtService,
-    @Inject(jwtConfig.KEY)
-    private readonly config: ConfigType<typeof jwtConfig>,
+    private readonly userQuery: UserQuery,
+    @Inject(jwtConfig.KEY) private readonly config: ConfigType<typeof jwtConfig>,
   ) {}
 
   async generateToken(
@@ -62,5 +64,134 @@ export class JwtUtil {
         ErrorCode.ERROR,
       );
     }
+  }
+
+  private async authMiddleware(accessToken: string, refreshToken: string) {
+    try {
+      const accessPayload = (await this.jwtService.verify(accessToken, {
+        secret: this.config.jwtSecretKey,
+      })) as JwtPayload;
+
+      return { status: 'access', payload: accessPayload };
+    } catch (accessError) {
+      this.logger.warn(
+        'Access Token invalid or expired. Trying refresh token.',
+        accessError,
+      );
+
+      try {
+        const refreshPayload = (await this.jwtService.verify(refreshToken, {
+          secret: this.config.jwtRefreshSecretKey,
+        })) as JwtPayload;
+
+        const uId = refreshPayload.uId;
+        const userData = await this.userQuery.findUserById(uId);
+
+        if (!userData) {
+          throw new GlobalException(
+            '유효하지 않은 토큰입니다.',
+            401,
+            ErrorCode.INVALID_TOKEN,
+          );
+        }
+
+        if (refreshToken !== userData.uRefreshToken) {
+          this.logger.error('Refresh token mismatch.');
+          throw new GlobalException(
+            '유효하지 않은 토큰입니다.',
+            401,
+            ErrorCode.INVALID_TOKEN,
+          );
+        }
+
+        const newAccessToken = await this.generateAccessToken(refreshPayload);
+
+        return {
+          status: 'refresh',
+          newAccess: newAccessToken,
+          newPayload: userData,
+        };
+      } catch (refreshError) {
+        this.logger.error('Refresh Token verification failed.');
+        this.logger.error(refreshError);
+        throw new GlobalException(
+          '토큰 검증에 실패했습니다.',
+          401,
+          ErrorCode.UNAUTHORIZED,
+        );
+      }
+    }
+  }
+
+  async verifyToken(accessToken: string, refreshToken: string) {
+    const result = await this.authMiddleware(accessToken, refreshToken);
+
+    try {
+      if (result.status === 'access') {
+        const userData = await this.userQuery.findUserById(
+          result.payload?.uId ?? '',
+        );
+
+        if (!userData || refreshToken !== userData.uRefreshToken) {
+          this.logger.error('Refresh token mismatch.');
+          return { status: false, payload: null };
+        }
+
+        return { status: true, payload: result.payload };
+      }
+
+      if (result.status === 'refresh') {
+        return {
+          status: true,
+          payload: result.newPayload,
+          newAccess: result.newAccess,
+        };
+      }
+
+      this.logger.error('Token is not valid.');
+      return { status: false, payload: null };
+    } catch (error) {
+      this.logger.error('JwtUtil.verifyToken Failed.');
+      this.logger.error(error);
+      throw new Error('JwtUtil.verifyToken Failed.');
+    }
+  }
+
+  async extractTokens(
+    request: any,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const authorization = request.headers.authorization;
+    const cookie = request.headers.cookie;
+
+    if (!authorization || !cookie) {
+      throw new GlobalException(
+        '헤더 또는 쿠키가 필요합니다.',
+        401,
+        ErrorCode.USER_NOT_AUTHENTICATION,
+      );
+    }
+
+    const [aType, aValue] = authorization.split(' ');
+
+    if (aType !== 'Bearer') {
+      throw new GlobalException(
+        '유효하지 않은 토큰입니다.',
+        401,
+        ErrorCode.INVALID_TOKEN,
+      );
+    }
+
+    const refreshToken = cookie.split('; ').find((cookie: string) => cookie.startsWith('refreshToken='));
+    const [rType, rValue] = refreshToken.split('=');
+
+    if (!refreshToken || rType !== 'refreshToken') {
+      throw new GlobalException(
+        '유효하지 않은 토큰입니다.',
+        401,
+        ErrorCode.INVALID_TOKEN,
+      );
+    }
+
+    return { accessToken: aValue, refreshToken: rValue };
   }
 }

--- a/src/core/utils/jwt.ts
+++ b/src/core/utils/jwt.ts
@@ -29,7 +29,7 @@ export class JwtUtil {
     const accessToken = await this.generateAccessToken(payload);
     const refreshToken = await this.generateRefreshToken(payload);
 
-    return { accessToken, refreshToken };
+    return { accessToken: `Bearer ${accessToken}`, refreshToken };
   }
 
   private async generateAccessToken(payload: JwtPayload): Promise<string> {

--- a/src/core/utils/time.ts
+++ b/src/core/utils/time.ts
@@ -1,0 +1,14 @@
+import * as dayjs from 'dayjs';
+import * as timezone from 'dayjs/plugin/timezone';
+import * as utc from 'dayjs/plugin/utc';
+
+dayjs.extend(timezone);
+dayjs.extend(utc);
+
+/**
+ * 서울 시간 반환
+ * @returns 서울 시간
+ */
+export function getSeoulTimestamp() {
+  return dayjs().tz('Asia/Seoul').valueOf();
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #3 

## 🏃‍ Task
- 회원가입 API 구현 (/auth/signUp)
- 로그인, 로그아웃 API 구현 (/auth/login, /auth/logout)
- 유저 정보 조회 API 구현 (/auth/user), 헤더 적용(Authorization, Cookie)
- JWT 토큰 검증 로직 및 AuthGuard 구현 (로그아웃, 유저 정보 조회 시 적용) 📍 관련커밋: {61f190c5f7531bcf9cf36be3165888fbb4344a9f}
- 구현 API Swagger 문서화 (응답 형식 지정 후 일관되게 작성) 📍 관련커밋: {4bf8a56393e9815d520fab5fe3d161ea848ad706}

## 💬 To Reviews 
로그아웃 및 유저 정보는 request header의 Authorization, Cookie 의 값을 통해 user 정보를 판단하도록 AuthGuard 설정하였습니다.
앞으로 로그인 후에 요청하는 모든 API에는 middleware로 AuthGuard가 적용될 예정입니다!

프론트에서 회원가입, 로그인 시 반환되는 accessToken과 refreshToken을 각각 Authorization, Cookie 헤더에 넣어서 요청하셔야지 AuthGuard 통과 가능합니다!

저장 형식은 아래와 같습니다! 프론트 쪽에서 참고하면 좋을 것 같아요~ (Swagger에서도 확인 가능)
Authorization: `Bearer {accessToken}`
Cookie: `refreshToken={refreshToken}`

빠진 거 없도록 Api 및 Authguard 테스트까지 완료 했는데
그래도 JWT 검증 로직 부분 한번 더 확인 부탁드려요~ :)

## 📄 Reference
- None